### PR TITLE
Minor fixes to prevent `CRAN` notes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parabar
 Title: Progress Bar for Parallel Tasks
-Version: 0.9.0
+Version: 0.9.1
 Authors@R:
     person(given = "Mihai",
            family = "Constantin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 # parabar 0.9.0
+## Fixed
+- Update broken links in `README` file.
+- Disable examples for `par_sapply` exported function due to exceeding the
+  `CRAN` time limit for running examples.
+# parabar 0.9.0
 ## Added
 - Add package website via `pkgdown` and `GitHub` pages.
 - Add `GitHub` workflow to automatically check the package on several platforms

--- a/README.md
+++ b/README.md
@@ -456,4 +456,4 @@ Check out the UML diagram below for a quick overview of the package design.
 
 ## License
 The code in this repository is licensed under the [MIT
-license](https://opensource.org/license/mit).
+license](https://opensource.org/license/mit/).

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 <!-- badges: start -->
 <p align="center">
     <a href="https://www.repostatus.org/#active"><img src="https://www.repostatus.org/badges/latest/active.svg" alt="Repository status"/></a>
-    <a href="https://github.com/mihaiconstantin/parbar/releases"><img src="https://img.shields.io/github/v/release/mihaiconstantin/parabar?display_name=tag&sort=semver"/></a>
-    <a href="https://www.r-pkg.org/pkg/parabar"><img src="https://www.r-pkg.org/badges/version/parabar" alt="CRAN version"/></a>
-    <a href="https://www.r-pkg.org/pkg/parabar"><img src="https://cranlogs.r-pkg.org/badges/grand-total/parabar" alt="CRAN RStudio mirror downloads"/></a>
+    <a href="https://github.com/mihaiconstantin/parabar/releases"><img src="https://img.shields.io/github/v/release/mihaiconstantin/parabar?display_name=tag&sort=semver"/></a>
+    <a href="https://github.com/mihaiconstantin/parabar"><img src="https://www.r-pkg.org/badges/version/parabar" alt="CRAN version"/></a>
+    <a href="https://github.com/mihaiconstantin/parabar"><img src="https://cranlogs.r-pkg.org/badges/grand-total/parabar" alt="CRAN RStudio mirror downloads"/></a>
     <a href="https://github.com/mihaiconstantin/parabar/actions"><img src="https://github.com/mihaiconstantin/parabar/workflows/R-CMD-check/badge.svg" alt="R-CMD-check" /></a>
 </p>
 <!-- badges: end -->
@@ -456,4 +456,4 @@ Check out the UML diagram below for a quick overview of the package design.
 
 ## License
 The code in this repository is licensed under the [MIT
-license](https://opensource.org/licenses/MIT).
+license](https://opensource.org/license/mit).

--- a/man-roxygen/par-sapply.R
+++ b/man-roxygen/par-sapply.R
@@ -36,6 +36,8 @@
 #' `fun`. The output format resembles that of [base::sapply()].
 #'
 #' @examples
+#' \dontrun{
+#'
 #' # Start an asynchronous backend.
 #' backend <- start_backend(cores = 2, cluster_type = "psock", backend_type = "async")
 #'
@@ -74,6 +76,7 @@
 #'
 #' # Stop the backend.
 #' stop_backend(backend)
+#' }
 #'
 #' # Run the task using the `base::sapply` (i.e., non-parallel).
 #' results <- par_sapply(NULL, 1:300, function(x) { Sys.sleep(0.01) })

--- a/man/par_sapply.Rd
+++ b/man/par_sapply.Rd
@@ -44,6 +44,8 @@ context is also used if the progress tracking is disabled via the
 }
 }
 \examples{
+\dontrun{
+
 # Start an asynchronous backend.
 backend <- start_backend(cores = 2, cluster_type = "psock", backend_type = "async")
 
@@ -82,6 +84,7 @@ results <- par_sapply(backend, 1:300, function(x) { Sys.sleep(0.01) })
 
 # Stop the backend.
 stop_backend(backend)
+}
 
 # Run the task using the `base::sapply` (i.e., non-parallel).
 results <- par_sapply(NULL, 1:300, function(x) { Sys.sleep(0.01) })


### PR DESCRIPTION
- Remove broke URLs in `README`
- Disable examples that take too long to execute.